### PR TITLE
Improve the compile.sh script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,4 +12,4 @@ jobs:
       - name: install g++
         run: sudo apt install -y g++
       - name: check build
-        run: source ./compile.sh
+        run: source ./compile.sh .

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .vscode/
 report.txt
 
+# Binaries
+/bin/

--- a/compile.sh
+++ b/compile.sh
@@ -1,5 +1,17 @@
 #!/bin/bash
-for FILE in exercises/*.cpp; do
+
+SCRIPT_DIR=$(dirname $0)
+BIN_DIR=$SCRIPT_DIR/bin
+
+# create the 'bin' directory, if needed
+if [ ! -d "$BIN_DIR" ]; then
+  mkdir bin
+fi
+
+for FILE in $SCRIPT_DIR/exercises/*.cpp; do
+  # remove the .cpp extension
+  FILE_NO_EXT=$(basename "$FILE" .cpp)
+
   printf "Compiling: $FILE ->\n"
-  g++ $FILE -std=c++11 -c
+  g++ "$FILE" -std=c++11 -o "$BIN_DIR/$FILE_NO_EXT"
 done

--- a/exercises/binary_converter.cpp
+++ b/exercises/binary_converter.cpp
@@ -5,3 +5,8 @@
   Insert first number: 8
   The binary number is: 1000
 */
+
+int main()
+{
+
+}

--- a/exercises/calculator.cpp
+++ b/exercises/calculator.cpp
@@ -10,3 +10,8 @@
   Multiplication: 8
   Division: 2
 */
+
+int main()
+{
+
+}

--- a/exercises/random_number.cpp
+++ b/exercises/random_number.cpp
@@ -4,3 +4,8 @@
   Output:
   The random number is: 4
 */
+
+int main()
+{
+
+}

--- a/exercises/risk-risiko.cpp
+++ b/exercises/risk-risiko.cpp
@@ -27,3 +27,8 @@
   M 3 vs 3 => blue win
   O 2 vs 1 => red win
 */
+
+int main()
+{
+
+}

--- a/exercises/sum.cpp
+++ b/exercises/sum.cpp
@@ -6,3 +6,8 @@
   Insert the second number: 2
   Sum: 3
 */
+
+int main()
+{
+
+}


### PR DESCRIPTION
Previously, the compile.sh script compiled without linking (-c option for g++) generating non-executable object files. This commit makes the script compile *and link* all the exercise files.
The executable files will also be put in the 'bin' subdirectory, to avoid polluting the root directory of the repository.